### PR TITLE
Fixing compatibility with python 3

### DIFF
--- a/simplemde/widgets.py
+++ b/simplemde/widgets.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import uuid
 from django import forms
 from django.forms import widgets
@@ -20,7 +21,7 @@ class SimpleMDEEditor(widgets.Textarea):
     def options(self):
         options = GLOBAL_OPTIONS.copy()
         if 'autosave' in options and options['autosave'].get('enabled', False):
-            options['autosave']['uniqueId'] = unicode(uuid.uuid4())
+            options['autosave']['uniqueId'] = str(uuid.uuid4())
         options.update(self.custom_options)
         return options
 


### PR DESCRIPTION
Just realised that there is another python 3 issue when using autosave:
`unicode(uuid.uuid4())` => `NameError: name 'unicode' is not defined`
With python 3 it would be just `unicode(uuid.uuid4())`
