### PR TITLE
Add support for Django 2.0

### DIFF
--- a/simplemde/widgets.py
+++ b/simplemde/widgets.py
@@ -3,8 +3,12 @@ import uuid
 from django import forms
 from django.forms import widgets
 from django.utils.safestring import mark_safe
-from django.core.urlresolvers import reverse_lazy
 from django.conf import settings
+
+try:
+    from django.core.urlresolvers import reverse_lazy
+except ImportError:
+    from django.urls import reverse_lazy
 
 from .utils import json_dumps
 

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -17,6 +17,6 @@ from django.conf.urls import include, url
 from django.contrib import admin
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^', include('markdown.urls'))
 ]


### PR DESCRIPTION
* Change reverse_lazy import in widgets.py to support Django 2.0
* Update urls.py in testproject to use new style of url Includes

Changes are backward compatible with Django 1.11.8. The url's file in the test project may not be compatible with earlier versions 