### PR TITLE
Fix django 4 import force_text error

### DIFF
--- a/simplemde/utils.py
+++ b/simplemde/utils.py
@@ -2,9 +2,12 @@ from django.core.exceptions import ImproperlyConfigured
 from importlib import import_module
 
 try:
-    from django.utils.encoding import force_text
+    # django > 3 
+    from django.utils.encoding import force_str
 except ImportError:
-    from django.utils.encoding import force_unicode as force_text
+    # django 2 
+    from django.utils.encoding import force_unicode as force_str
+
 from django.utils.functional import Promise
 
 import json
@@ -14,7 +17,7 @@ class LazyEncoder(json.JSONEncoder):
 
     def default(self, obj):
         if isinstance(obj, Promise):
-            return force_text(obj)
+            return force_str(obj)
         return super(LazyEncoder, self).default(obj)
 
 


### PR DESCRIPTION
`django.utils.encoding.force_text` was deprecated in django 3 and removed in django 4, breaking this library. Fortunately `force_str` has identical behaviour so this is an easy fix.  