### PR TITLE
Fix duplicate editors when script is loaded again

### DIFF
--- a/simplemde/static/simplemde/simplemde.init.js
+++ b/simplemde/static/simplemde/simplemde.init.js
@@ -14,8 +14,10 @@ if (!!simplemdeJQuery) {
     simplemdeJQuery.each(simplemdeJQuery('.simplemde-box'), function(i, elem) {
       var options = JSON.parse(simplemdeJQuery(elem).attr('data-simplemde-options'));
       options['element'] = elem;
-      var simplemde = new SimpleMDE(options);
-      elem.SimpleMDE = simplemde;
+      if (elem.SimpleMDE === undefined) {
+        var simplemde = new SimpleMDE(options);
+        elem.SimpleMDE = simplemde;
+      }
     });
   });
 }


### PR DESCRIPTION
When the Django widget `SimpleMDEEditor` is used multiple times on the same page, `simplemde.init.js` can be loaded multiple times, causing multiple editor windows to be rendered. 